### PR TITLE
Add functionality to remove authorized_keys not managed by Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ansible-proserver-system
-An Ansible role that sets up a Proserver system
+An Ansible role that sets up a Proserver system.
 
 ### Features
 | Variable name | Default value | Description |
 | ------------- | ------------- | ----------- |
-| `system.features.authorized_keys_delete` | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. When this variable is set to `yes`, removing a key from the variables will remove it from the target host during the next run |
-| `system.features.users_delete` | no | Whether removing a user from the variables should automatically remove it from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users
+| `system.features.authorized_keys_delete` | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. When this variable is set to `yes`, removing a key from the variables will remove it from the target host during the next run. |
+| `system.features.users_delete` | no | Whether removing a user from the variables should automatically remove them from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ An Ansible role that sets up a Proserver system
 ### Features
 | Variable name | Default value | Description |
 | ------------- | ------------- | ----------- |
-| `system.features.authorized_keys_delete` | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. Removing an authorized keys from the variables will remove it from the target host during the next run |
+| `system.features.authorized_keys_delete` | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. When this variable is set to `yes`, removing a key from the variables will remove it from the target host during the next run |
 | `system.features.users_delete` | no | Whether removing a user from the variables should automatically remove it from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ An Ansible role that sets up a Proserver system
 ### Features
 | Variable name | Default value | Description |
 | ------------- | ------------- | ----------- |
-| system.features.authorized_keys_delete | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. Removing an authorized keys from the variables will remove it from the target host during the next run |
-| system.features.users_delete | no | Whether removing a user from the variables should automatically remove it from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users
+| `system.features.authorized_keys_delete` | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. Removing an authorized keys from the variables will remove it from the target host during the next run |
+| `system.features.users_delete` | no | Whether removing a user from the variables should automatically remove it from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# ansible-proserver-system
+An Ansible role that sets up a Proserver system
+
+### Features
+| Variable name | Default value | Description |
+| ------------- | ------------- | ----------- |
+| system.features.authorized_keys_delete | no | Whether the public keys that aren't managed by Ansible should be removed from the target host. Removing an authorized keys from the variables will remove it from the target host during the next run |
+| system.features.users_delete | no | Whether removing a user from the variables should automatically remove it from the target hosts. Please note that you need to have ran the playbook at least once beforehand, so that Ansible can create a list of current users
+

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -15,6 +15,7 @@ system:
     users: yes
     sudoers: yes
     authorized_keys: yes
+    authorized_keys_delete: no
     motd: no
   prefix:
     sudoers: >-

--- a/tasks/authorized_keys.yaml
+++ b/tasks/authorized_keys.yaml
@@ -1,4 +1,41 @@
+---
+- name: Handle old key removal
+  when: system.features.authorized_keys_delete | default(False)
+  block:
+    - name: Ensure that the .ssh folder exists
+      ansible.builtin.file:
+        path: "/home/{{ item }}/.ssh"
+        state: directory
+        mode: 0700
+        owner: "{{ item }}"
+      loop: "{{ system.users.keys() }}"
+
+    - name: Ensure that the authorized_keys file exists
+      ansible.builtin.file:
+        path: "/home/{{ item }}/.ssh/authorized_keys"
+        state: touch
+        modification_time: preserve
+        access_time: preserve
+      loop: "{{ system.users.keys() }}"
+
+    - name: Create a backup of current authorized keys
+      changed_when: false
+      ansible.builtin.copy:
+        remote_src: yes
+        src: "/home/{{ item }}/.ssh/authorized_keys"
+        dest: "/home/{{ item }}/.ssh/authorized_keys.bak"
+      loop: "{{ system.users.keys() }}"
+
+    - name: Clear authorized keys
+      changed_when: false
+      ansible.builtin.file:
+        state: absent
+        path: "/home/{{ item }}/.ssh/authorized_keys"
+      loop: "{{ system.users.keys() }}"
+
 - name: Add authorized keys
+  register: authorized_keys_added
+  changed_when: authorized_keys_added.changed and not (system.features.authorized_keys_delete | default(False))
   loop: >-
     {%- set user_authorized_key = [] -%}
     {%- for user, user_info in system.users.items() -%}
@@ -20,3 +57,21 @@
   authorized_key:
     user: "{{ item.user }}"
     key: "{{ item.key }}"
+
+- name: Clean up after key removal
+  when: system.features.authorized_keys_delete | default(False)
+  block:
+    - name: Check if any keys have been added or removed
+      ansible.builtin.shell:
+        cmd: "diff /home/{{ item }}/.ssh/authorized_keys /home/{{ item }}/.ssh/authorized_keys.bak"
+      register: diff_output
+      failed_when: "diff_output.rc > 1"
+      changed_when: "diff_output.rc > 0"
+      loop: "{{ system.users.keys() }}"
+
+    - name: Remove the backup file
+      changed_when: false
+      ansible.builtin.file:
+        path: "/home/{{ item }}/.ssh/authorized_keys.bak"
+        state: absent
+      loop: "{{ system.users.keys() }}"

--- a/tasks/authorized_keys.yaml
+++ b/tasks/authorized_keys.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Handle old key removal
+- name: Template the auhtorized_keys out
   when: system.features.authorized_keys_delete | default(False)
   block:
     - name: Ensure that the .ssh folder exists
@@ -10,32 +10,18 @@
         owner: "{{ item }}"
       loop: "{{ system.users.keys() }}"
 
-    - name: Ensure that the authorized_keys file exists
-      ansible.builtin.file:
-        path: "/home/{{ item }}/.ssh/authorized_keys"
-        state: touch
-        modification_time: preserve
-        access_time: preserve
+    - name: Template out the authorized_keys
+      ansible.builtin.template:
+        dest: "/home/{{ item }}/.ssh/authorized_keys"
+        owner: "{{ item }}"
+        mode: 0600
+        src: authorized_keys.j2
       loop: "{{ system.users.keys() }}"
-
-    - name: Create a backup of current authorized keys
-      changed_when: false
-      ansible.builtin.copy:
-        remote_src: yes
-        src: "/home/{{ item }}/.ssh/authorized_keys"
-        dest: "/home/{{ item }}/.ssh/authorized_keys.bak"
-      loop: "{{ system.users.keys() }}"
-
-    - name: Clear authorized keys
-      changed_when: false
-      ansible.builtin.file:
-        state: absent
-        path: "/home/{{ item }}/.ssh/authorized_keys"
-      loop: "{{ system.users.keys() }}"
+      vars:
+        ssh_user: "{{ item }}"
 
 - name: Add authorized keys
-  register: authorized_keys_added
-  changed_when: authorized_keys_added.changed and not (system.features.authorized_keys_delete | default(False))
+  when: not system.features.authorized_keys_delete | default(False)
   loop: >-
     {%- set user_authorized_key = [] -%}
     {%- for user, user_info in system.users.items() -%}
@@ -57,21 +43,3 @@
   authorized_key:
     user: "{{ item.user }}"
     key: "{{ item.key }}"
-
-- name: Clean up after key removal
-  when: system.features.authorized_keys_delete | default(False)
-  block:
-    - name: Check if any keys have been added or removed
-      ansible.builtin.shell:
-        cmd: "diff /home/{{ item }}/.ssh/authorized_keys /home/{{ item }}/.ssh/authorized_keys.bak"
-      register: diff_output
-      failed_when: "diff_output.rc > 1"
-      changed_when: "diff_output.rc > 0"
-      loop: "{{ system.users.keys() }}"
-
-    - name: Remove the backup file
-      changed_when: false
-      ansible.builtin.file:
-        path: "/home/{{ item }}/.ssh/authorized_keys.bak"
-        state: absent
-      loop: "{{ system.users.keys() }}"

--- a/templates/authorized_keys.j2
+++ b/templates/authorized_keys.j2
@@ -1,0 +1,9 @@
+{% for name, key in system['users'][ssh_user]['authorized_keys'].items() %}
+{% if (key | type_debug == 'list') %}
+{% for k in key %}
+{{ k }}
+{% endfor %}
+{% else %}
+{{ key }}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
The feature is off by default and needs to be enabled explicitely by setting the variable system.features.authorized_keys_delete to 'yes'