### PR TITLE
Update Ansible task to correctly remove old NodeSource repo

### DIFF
--- a/tasks/apt.yaml
+++ b/tasks/apt.yaml
@@ -4,7 +4,7 @@
 
 - name: Remove legacy NodeSource repository
   ansible.builtin.file:
-    path: /etc/apt/sources.list.d/deb_nodesource_com_node_14_x.list
+    path: /etc/apt/sources.list.d/nodesource.list
     state: absent
   when: nodejs.version is defined
 


### PR DESCRIPTION
This commit corrects the file path in the "Remove legacy NodeSource repository" Ansible task. Previously, the task was removing 'deb_nodesource_com_node_14_x.list'. However, based on the current repository setup and the file generation convention, it should be targeting 'nodesource.list'.